### PR TITLE
NPC and interaction  system

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -36,3 +36,12 @@ jump={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
 ]
 }
+interact={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
+]
+}
+
+[physics]
+
+common/physics_interpolation=true

--- a/scenes/npc.tscn
+++ b/scenes/npc.tscn
@@ -1,0 +1,21 @@
+[gd_scene format=3 uid="uid://hgpyh1oca1cd"]
+
+[ext_resource type="Script" uid="uid://dl6ovh6i67jid" path="res://scripts/npc.gd" id="1_nh2m4"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_abqhh"]
+radius = 47.0
+
+[node name="NPC" type="Area2D" unique_id=1055926722]
+script = ExtResource("1_nh2m4")
+hidden_value = 7
+prompt_text = "Talk"
+
+[node name="InteractionRange" type="CollisionShape2D" parent="." unique_id=1819764416]
+shape = SubResource("CircleShape2D_abqhh")
+
+[node name="ColorRect" type="ColorRect" parent="." unique_id=548627754]
+offset_left = -16.0
+offset_top = -32.0
+offset_right = 16.0
+offset_bottom = 16.0
+color = Color(0.627451, 0.22352941, 1, 1)

--- a/scenes/test_level.tscn
+++ b/scenes/test_level.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://crk33t2kvalrs"]
 
 [ext_resource type="PackedScene" uid="uid://player" path="res://scenes/player.tscn" id="1_player"]
+[ext_resource type="PackedScene" uid="uid://hgpyh1oca1cd" path="res://scenes/npc.tscn" id="2_paw1w"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_floor"]
 size = Vector2(2000, 32)
@@ -18,7 +19,7 @@ offset_bottom = 700.0
 color = Color(0.15, 0.15, 0.2, 1)
 
 [node name="Player" parent="." unique_id=1857081638 instance=ExtResource("1_player")]
-position = Vector2(300, 300)
+position = Vector2(314, 458)
 
 [node name="Floor" type="StaticBody2D" parent="." unique_id=1844053799]
 position = Vector2(500, 500)
@@ -45,3 +46,6 @@ offset_top = -16.0
 offset_right = 100.0
 offset_bottom = 16.0
 color = Color(0.5, 0.5, 0.55, 1)
+
+[node name="NPC" parent="." unique_id=1055926722 instance=ExtResource("2_paw1w")]
+position = Vector2(-35, 467)

--- a/scripts/interactable.gd
+++ b/scripts/interactable.gd
@@ -1,0 +1,27 @@
+class_name Interactable
+extends Area2D
+
+@export var prompt_text: String = "Interact"
+
+var _prompt_label: Label
+
+func _ready() -> void:
+	collision_layer = 2
+	collision_mask = 0
+	_prompt_label = Label.new()
+	_prompt_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_prompt_label.add_theme_font_size_override("font_size", 14)
+	add_child(_prompt_label)
+	_prompt_label.hide()
+
+func show_prompt() -> void:
+	_prompt_label.text = "[E] " + prompt_text
+	_prompt_label.position = Vector2(-_prompt_label.size.x / 2.0, -80)
+	_prompt_label.show()
+
+func hide_prompt() -> void:
+	_prompt_label.hide()
+
+## Override in subclasses to define interaction behaviour
+func interact(_interactor: Node) -> void:
+	pass

--- a/scripts/interactable.gd.uid
+++ b/scripts/interactable.gd.uid
@@ -1,0 +1,1 @@
+uid://dq2iit6iwbjmj

--- a/scripts/npc.gd
+++ b/scripts/npc.gd
@@ -1,0 +1,82 @@
+class_name NPC
+extends Interactable
+
+signal patience_changed(new_patience: float, max_patience: float)
+signal patience_depleted
+signal number_revealed(number: int)
+signal answer_refused
+
+## Number hidden from the player — revealed only when asked
+@export var hidden_value: int = 0
+
+## Total patience pool; each interaction costs patience_per_ask
+@export var max_patience: float = 5.0
+@export var patience_per_ask: float = 1.0
+
+## How fast patience drains per second while the NPC is following the player
+@export var follow_drain_rate: float = 0.1
+
+var patience: float
+var is_following: bool = false
+
+var _follow_target: Node2D = null
+
+
+func _ready() -> void:
+	prompt_text = "Talk"
+	patience = max_patience
+	super._ready()
+
+
+func _process(delta: float) -> void:
+	if is_following and _follow_target != null:
+		_tick_follow(delta)
+
+
+# Called when the player presses interact while in range
+func interact(_interactor: Node) -> void:
+	var n := ask_number()
+	if n != -1:
+		print("NPC mówi: mój numer to ", n)
+	else:
+		print("NPC ignoruje cię.")
+
+
+# Returns the hidden value and costs patience.
+# Returns -1 and emits answer_refused when patience is depleted.
+func ask_number() -> int:
+	if patience <= 0.0:
+		answer_refused.emit()
+		return -1
+
+	_decrease_patience(patience_per_ask)
+	number_revealed.emit(hidden_value)
+	return hidden_value
+
+
+func ask_to_follow(target: Node2D) -> void:
+	is_following = true
+	_follow_target = target
+
+
+func stop_following() -> void:
+	is_following = false
+	_follow_target = null
+
+
+func restore_patience(amount: float) -> void:
+	patience = minf(patience + amount, max_patience)
+	patience_changed.emit(patience, max_patience)
+
+
+func _decrease_patience(amount: float) -> void:
+	patience = maxf(patience - amount, 0.0)
+	patience_changed.emit(patience, max_patience)
+	if patience <= 0.0:
+		patience_depleted.emit()
+
+
+func _tick_follow(delta: float) -> void:
+	_decrease_patience(follow_drain_rate * delta)
+	# Placeholder — movement will be implemented with CharacterBody2D refactor
+	global_position = global_position.lerp(_follow_target.global_position + Vector2(40, 0), delta * 3.0)

--- a/scripts/npc.gd.uid
+++ b/scripts/npc.gd.uid
@@ -1,0 +1,1 @@
+uid://dl6ovh6i67jid

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -16,9 +16,31 @@ extends CharacterBody2D
 ## Jump buffer — how early before landing a jump input is accepted
 @export var jump_buffer_time: float = 0.12
 
+## Radius in pixels within which interactables are detected
+@export var interaction_radius: float = 60.0
+
 var _coyote_timer: float = 0.0
 var _jump_buffer_timer: float = 0.0
 var _was_on_floor: bool = false
+var _current_interactable: Interactable = null
+
+
+func _ready() -> void:
+	_setup_interaction_area()
+
+
+func _setup_interaction_area() -> void:
+	var area := Area2D.new()
+	area.collision_layer = 0
+	area.collision_mask = 2
+	var shape := CollisionShape2D.new()
+	var circle := CircleShape2D.new()
+	circle.radius = interaction_radius
+	shape.shape = circle
+	area.add_child(shape)
+	add_child(area)
+	area.area_entered.connect(_on_interactable_entered)
+	area.area_exited.connect(_on_interactable_exited)
 
 
 func _physics_process(delta: float) -> void:
@@ -26,8 +48,26 @@ func _physics_process(delta: float) -> void:
 	_update_timers(delta)
 	_handle_jump()
 	_handle_horizontal(delta)
+	_handle_interact()
 	move_and_slide()
 	_was_on_floor = is_on_floor()
+
+
+func _handle_interact() -> void:
+	if Input.is_action_just_pressed("interact") and _current_interactable != null:
+		_current_interactable.interact(self)
+
+
+func _on_interactable_entered(area: Area2D) -> void:
+	if area is Interactable:
+		_current_interactable = area as Interactable
+		_current_interactable.show_prompt()
+
+
+func _on_interactable_exited(area: Area2D) -> void:
+	if area == _current_interactable:
+		_current_interactable.hide_prompt()
+		_current_interactable = null
 
 
 func _apply_gravity(delta: float) -> void:


### PR DESCRIPTION
Add generic interaction system and NPC base class

  Summary

  - Adds Interactable (extends Area2D) as a base class for any interactable object — shows a
  world-space prompt label when the player enters range
  - Extends Player with a dynamically-created detection Area2D (radius 60px, collision mask 2) and
  handles the interact input action (key E)                                                         
  - Adds NPC (extends Interactable) with a hidden_value, a patience pool that drains on each ask and
   while following, and signals for number_revealed, patience_changed, patience_depleted, and       
  answer_refused                                            
  - Registers the interact action (key E) in project.godot                                          
                                                                                                    
  How to extend
                                                                                                    
  Create a new class extending Interactable and override interact(_interactor). For a new NPC type, 
  extend NPC and override ask_number() or interact().
  
  

https://github.com/user-attachments/assets/5d6de102-73a5-4ce7-a973-7a54556b4115