### PR TITLE
Assign random values to NPCs

### DIFF
--- a/scenes/npc.tscn
+++ b/scenes/npc.tscn
@@ -2,17 +2,27 @@
 
 [ext_resource type="Script" uid="uid://dl6ovh6i67jid" path="res://scripts/npc.gd" id="1_nh2m4"]
 [ext_resource type="Resource" uid="uid://be1mdcqhuridg" path="res://dialogues/npc_dialog.dialogue" id="2_abqhh"]
+[ext_resource type="Script" path="res://scripts/npc_interaction_area.gd" id="3_b6k20"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_abqhh"]
 radius = 47.0
 
-[node name="NPC" type="Area2D" unique_id=1055926722]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_body"]
+size = Vector2(24, 32)
+
+[node name="NPC" type="CharacterBody2D" unique_id=1055926722]
 script = ExtResource("1_nh2m4")
 hidden_value = 7
 dialogue_resource = ExtResource("2_abqhh")
 prompt_text = "Talk"
 
-[node name="InteractionRange" type="CollisionShape2D" parent="." unique_id=1819764416]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=1022001]
+shape = SubResource("RectangleShape2D_body")
+
+[node name="InteractionArea" type="Area2D" parent="." unique_id=90852234]
+script = ExtResource("3_b6k20")
+
+[node name="InteractionRange" type="CollisionShape2D" parent="InteractionArea" unique_id=1819764416]
 shape = SubResource("CircleShape2D_abqhh")
 
 [node name="ColorRect" type="ColorRect" parent="." unique_id=548627754]

--- a/scenes/test_level_npc.tscn
+++ b/scenes/test_level_npc.tscn
@@ -25,16 +25,16 @@ z_index = 10
 position = Vector2(300, 300)
 
 [node name="NPC" parent="." unique_id=1055926722 instance=ExtResource("2_fd1ik")]
-position = Vector2(106, 470)
+position = Vector2(106, 468)
 
 [node name="NPC2" parent="." instance=ExtResource("2_fd1ik")]
-position = Vector2(834, 470)
+position = Vector2(834, 468)
 
 [node name="NPC3" parent="." instance=ExtResource("2_fd1ik")]
-position = Vector2(498, 347)
+position = Vector2(498, 348)
 
 [node name="NPC4" parent="." instance=ExtResource("2_fd1ik")]
-position = Vector2(666, 347)
+position = Vector2(666, 348)
 
 [node name="Floor" type="StaticBody2D" parent="." unique_id=1844053799]
 position = Vector2(500, 500)

--- a/scenes/test_level_npc.tscn
+++ b/scenes/test_level_npc.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="PackedScene" uid="uid://player" path="res://scenes/player.tscn" id="1_5620j"]
 [ext_resource type="PackedScene" uid="uid://cyxnskuxvd5kv" path="res://scenes/npc.tscn" id="2_fd1ik"]
+[ext_resource type="Script" path="res://scripts/level_initializer.gd" id="3_x10ad"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_floor"]
 size = Vector2(2000, 32)
@@ -10,6 +11,7 @@ size = Vector2(2000, 32)
 size = Vector2(200, 32)
 
 [node name="TestLevel" type="Node2D" unique_id=2124674192]
+script = ExtResource("3_x10ad")
 
 [node name="Background" type="ColorRect" parent="." unique_id=468872710]
 offset_left = -500.0
@@ -24,6 +26,15 @@ position = Vector2(300, 300)
 
 [node name="NPC" parent="." unique_id=1055926722 instance=ExtResource("2_fd1ik")]
 position = Vector2(106, 470)
+
+[node name="NPC2" parent="." instance=ExtResource("2_fd1ik")]
+position = Vector2(834, 470)
+
+[node name="NPC3" parent="." instance=ExtResource("2_fd1ik")]
+position = Vector2(498, 347)
+
+[node name="NPC4" parent="." instance=ExtResource("2_fd1ik")]
+position = Vector2(666, 347)
 
 [node name="Floor" type="StaticBody2D" parent="." unique_id=1844053799]
 position = Vector2(500, 500)

--- a/scripts/interactable.gd
+++ b/scripts/interactable.gd
@@ -22,6 +22,15 @@ func show_prompt() -> void:
 func hide_prompt() -> void:
 	_prompt_label.hide()
 
+
+func refresh_prompt() -> void:
+	if _prompt_label.visible:
+		show_prompt()
+
+
+func is_prompt_visible() -> bool:
+	return _prompt_label != null and _prompt_label.visible
+
 ## Override in subclasses to define interaction behaviour
 func interact(_interactor: Node) -> void:
 	pass

--- a/scripts/level_initializer.gd
+++ b/scripts/level_initializer.gd
@@ -1,0 +1,69 @@
+extends Node2D
+
+@export var first_pair_number: int = 1
+@export var fixed_seed: int = -1
+@export var print_assignments: bool = true
+
+
+func _ready() -> void:
+	_assign_random_hidden_values()
+
+
+func _assign_random_hidden_values() -> void:
+	var npcs: Array[NPC] = []
+	_collect_npcs(self, npcs)
+
+	if npcs.is_empty():
+		push_warning("Level initializer found no NPCs to randomize.")
+		return
+
+	if npcs.size() % 2 != 0:
+		push_error("Level initializer requires an even number of NPCs so every value has a pair.")
+		return
+
+	var pair_count := int(npcs.size() / 2)
+	var values := _build_pair_values(pair_count)
+	var rng := RandomNumberGenerator.new()
+	if fixed_seed >= 0:
+		rng.seed = fixed_seed
+	else:
+		rng.randomize()
+
+	_shuffle_values(values, rng)
+
+	for i in range(npcs.size()):
+		npcs[i].hidden_value = values[i]
+
+	if print_assignments:
+		_print_assignments(npcs)
+
+
+func _collect_npcs(node: Node, result: Array[NPC]) -> void:
+	for child in node.get_children():
+		if child is NPC:
+			result.append(child)
+
+		_collect_npcs(child, result)
+
+
+func _build_pair_values(pair_count: int) -> Array[int]:
+	var values: Array[int] = []
+	for i in range(pair_count):
+		var value := first_pair_number + i
+		values.append(value)
+		values.append(value)
+	return values
+
+
+func _shuffle_values(values: Array[int], rng: RandomNumberGenerator) -> void:
+	for i in range(values.size() - 1, 0, -1):
+		var swap_index := rng.randi_range(0, i)
+		var temp := values[i]
+		values[i] = values[swap_index]
+		values[swap_index] = temp
+
+
+func _print_assignments(npcs: Array[NPC]) -> void:
+	print("Randomized NPC number assignments:")
+	for npc in npcs:
+		print(" - ", npc.name, ": ", npc.hidden_value)

--- a/scripts/level_initializer.gd
+++ b/scripts/level_initializer.gd
@@ -10,8 +10,7 @@ func _ready() -> void:
 
 
 func _assign_random_hidden_values() -> void:
-	var npcs: Array[NPC] = []
-	_collect_npcs(self, npcs)
+	var npcs := _find_npcs()
 
 	if npcs.is_empty():
 		push_warning("Level initializer found no NPCs to randomize.")
@@ -38,12 +37,12 @@ func _assign_random_hidden_values() -> void:
 		_print_assignments(npcs)
 
 
-func _collect_npcs(node: Node, result: Array[NPC]) -> void:
-	for child in node.get_children():
-		if child is NPC:
-			result.append(child)
-
-		_collect_npcs(child, result)
+func _find_npcs() -> Array[NPC]:
+	var result: Array[NPC] = []
+	for node in find_children("*", "NPC", true, false):
+		if node is NPC:
+			result.append(node as NPC)
+	return result
 
 
 func _build_pair_values(pair_count: int) -> Array[int]:

--- a/scripts/level_initializer.gd.uid
+++ b/scripts/level_initializer.gd.uid
@@ -1,0 +1,1 @@
+uid://csel1o8fkra5

--- a/scripts/npc.gd
+++ b/scripts/npc.gd
@@ -13,23 +13,17 @@ signal answer_refused
 @export var max_patience: float = 5.0
 @export var patience_per_ask: float = 1.0
 
-## How fast patience drains per second while the NPC is following the player
-@export var follow_drain_rate: float = 0.1
-@export var follow_speed: float = 140.0
-@export var follow_acceleration: float = 700.0
-@export var follow_friction: float = 900.0
+## Physics tuning for the grounded NPC body
 @export var gravity: float = 900.0
 @export var prompt_text: String = "Talk"
 
-@export var dialogue_resource: DialogueResource        
-@export var dialogue_start: String = "start"                                                                                                                 
-														 
+@export var dialogue_resource: DialogueResource
+@export var dialogue_start: String = "start"
+
 var _is_dialogue_active: bool = false
 
 var patience: float
-var is_following: bool = false
 
-var _follow_target: Node2D = null
 @onready var _interaction_area: NPCInteractionArea = $InteractionArea
 
 
@@ -40,17 +34,16 @@ func _ready() -> void:
 
 func _physics_process(delta: float) -> void:
 	_apply_gravity(delta)
-	_update_follow_velocity(delta)
 	move_and_slide()
 
 
 # Called when the player presses interact while in range
-func interact(_interactor: Node) -> void:                                                                                                                    
-	if dialogue_resource == null or _is_dialogue_active:                                                                                                     
-		return                                          
-	_is_dialogue_active = true                                                                                                                               
+func interact(_interactor: Node) -> void:
+	if dialogue_resource == null or _is_dialogue_active:
+		return
+	_is_dialogue_active = true
 	DialogueManager.show_dialogue_balloon(dialogue_resource, dialogue_start)
-	await DialogueManager.dialogue_ended                                    
+	await DialogueManager.dialogue_ended
 	_is_dialogue_active = false
 
 # Returns the hidden value and costs patience.
@@ -64,21 +57,6 @@ func ask_number() -> int:
 	number_revealed.emit(hidden_value)
 	return hidden_value
 
-
-func ask_to_follow(target: Node2D) -> void:
-	is_following = true
-	_follow_target = target
-	prompt_text = "Wait"
-	_sync_prompt()
-
-
-func stop_following() -> void:
-	is_following = false
-	_follow_target = null
-	prompt_text = "Talk"
-	_sync_prompt()
-
-
 func restore_patience(amount: float) -> void:
 	patience = minf(patience + amount, max_patience)
 	patience_changed.emit(patience, max_patience)
@@ -89,19 +67,6 @@ func _decrease_patience(amount: float) -> void:
 	patience_changed.emit(patience, max_patience)
 	if patience <= 0.0:
 		patience_depleted.emit()
-
-
-func _update_follow_velocity(delta: float) -> void:
-	if is_following and is_instance_valid(_follow_target):
-		_decrease_patience(follow_drain_rate * delta)
-		var target_x := _follow_target.global_position.x + 40.0
-		var distance_x := target_x - global_position.x
-		if absf(distance_x) > 6.0:
-			velocity.x = move_toward(velocity.x, sign(distance_x) * follow_speed, follow_acceleration * delta)
-		else:
-			velocity.x = move_toward(velocity.x, 0.0, follow_friction * delta)
-	else:
-		velocity.x = move_toward(velocity.x, 0.0, follow_friction * delta)
 
 
 func _apply_gravity(delta: float) -> void:

--- a/scripts/npc.gd
+++ b/scripts/npc.gd
@@ -1,5 +1,5 @@
 class_name NPC
-extends Interactable
+extends CharacterBody2D
 
 signal patience_changed(new_patience: float, max_patience: float)
 signal patience_depleted
@@ -15,6 +15,11 @@ signal answer_refused
 
 ## How fast patience drains per second while the NPC is following the player
 @export var follow_drain_rate: float = 0.1
+@export var follow_speed: float = 140.0
+@export var follow_acceleration: float = 700.0
+@export var follow_friction: float = 900.0
+@export var gravity: float = 900.0
+@export var prompt_text: String = "Talk"
 
 @export var dialogue_resource: DialogueResource        
 @export var dialogue_start: String = "start"                                                                                                                 
@@ -25,17 +30,18 @@ var patience: float
 var is_following: bool = false
 
 var _follow_target: Node2D = null
+@onready var _interaction_area: NPCInteractionArea = $InteractionArea
 
 
 func _ready() -> void:
-	prompt_text = "Talk"
 	patience = max_patience
-	super._ready()
+	_sync_prompt()
 
 
-func _process(delta: float) -> void:
-	if is_following and _follow_target != null:
-		_tick_follow(delta)
+func _physics_process(delta: float) -> void:
+	_apply_gravity(delta)
+	_update_follow_velocity(delta)
+	move_and_slide()
 
 
 # Called when the player presses interact while in range
@@ -62,11 +68,15 @@ func ask_number() -> int:
 func ask_to_follow(target: Node2D) -> void:
 	is_following = true
 	_follow_target = target
+	prompt_text = "Wait"
+	_sync_prompt()
 
 
 func stop_following() -> void:
 	is_following = false
 	_follow_target = null
+	prompt_text = "Talk"
+	_sync_prompt()
 
 
 func restore_patience(amount: float) -> void:
@@ -81,7 +91,26 @@ func _decrease_patience(amount: float) -> void:
 		patience_depleted.emit()
 
 
-func _tick_follow(delta: float) -> void:
-	_decrease_patience(follow_drain_rate * delta)
-	# Placeholder — movement will be implemented with CharacterBody2D refactor
-	global_position = global_position.lerp(_follow_target.global_position + Vector2(40, 0), delta * 3.0)
+func _update_follow_velocity(delta: float) -> void:
+	if is_following and is_instance_valid(_follow_target):
+		_decrease_patience(follow_drain_rate * delta)
+		var target_x := _follow_target.global_position.x + 40.0
+		var distance_x := target_x - global_position.x
+		if absf(distance_x) > 6.0:
+			velocity.x = move_toward(velocity.x, sign(distance_x) * follow_speed, follow_acceleration * delta)
+		else:
+			velocity.x = move_toward(velocity.x, 0.0, follow_friction * delta)
+	else:
+		velocity.x = move_toward(velocity.x, 0.0, follow_friction * delta)
+
+
+func _apply_gravity(delta: float) -> void:
+	if not is_on_floor():
+		velocity.y += gravity * delta
+	elif velocity.y > 0.0:
+		velocity.y = 0.0
+
+
+func _sync_prompt() -> void:
+	if _interaction_area != null:
+		_interaction_area.sync_prompt_from_npc()

--- a/scripts/npc_interaction_area.gd
+++ b/scripts/npc_interaction_area.gd
@@ -1,0 +1,26 @@
+class_name NPCInteractionArea
+extends Interactable
+
+@onready var _npc: NPC = get_parent() as NPC
+
+
+func _ready() -> void:
+	super._ready()
+	_sync_prompt()
+
+
+func interact(interactor: Node) -> void:
+	if _npc != null:
+		_npc.interact(interactor)
+
+
+func sync_prompt_from_npc() -> void:
+	_sync_prompt()
+
+
+func _sync_prompt() -> void:
+	if _npc == null:
+		return
+
+	prompt_text = _npc.prompt_text
+	refresh_prompt()

--- a/scripts/npc_interaction_area.gd.uid
+++ b/scripts/npc_interaction_area.gd.uid
@@ -1,0 +1,1 @@
+uid://dcjlmqga8vtkc


### PR DESCRIPTION
Closes #13 

https://github.com/user-attachments/assets/164976e2-1e88-44f3-a68c-3ce8dcfc1675



This PR keeps randomized NPC hidden-value assignment at level start, but refactors NPCs into real CharacterBody2D physics bodies with proper collision and a separate interaction area. Because NPCs now rely on physics for grounding, the old hardcoded ground-snapping workaround in level initialization is removed. This gives us a cleaner and more reliable base for placement, following, and future NPC movement behavior.




