### PR TITLE
following/matching system

### DIFF
--- a/dialogues/npc_dialog.dialogue
+++ b/dialogues/npc_dialog.dialogue
@@ -4,7 +4,20 @@ if patience <= 0:
 	{{npc_name}}: {{get_patience_depleted_response()}}
 	=> END
 
-=> tell_owned_number
+{{npc_name}}: Hey, what's up?
+- Ask your number
+	=> tell_owned_number
+- Follow me [if is_following == false]
+	do start_following()
+	{{npc_name}}: Sure, I'll follow you!
+	=> END
+- Stop following [if is_following == true]
+	do stop_following()
+	{{npc_name}}: Okay, I'll stay here.
+	=> END
+- Match! [if can_attempt_match() == true]
+	do try_match()
+	=> END
 
 ~ start_nerd
 
@@ -12,11 +25,26 @@ if patience <= 0:
 	{{npc_name}}: {{get_patience_depleted_response()}}
 	=> END
 
-# First, check if the NPC has already been solved.
+{{npc_name}}: Yes? What do you want?
+- Ask your number
+	=> nerd_riddle
+- Follow me [if is_following == false]
+	do start_following()
+	{{npc_name}}: Very well, I'll accompany you.
+	=> END
+- Stop following [if is_following == true]
+	do stop_following()
+	{{npc_name}}: As you wish.
+	=> END
+- Match! [if can_attempt_match() == true]
+	do try_match()
+	=> END
+
+~ nerd_riddle
+
 if riddle_solved == true:
 	=> tell_owned_number
 
-# Determine which template to use based on the number of options
 if riddle_options.size() == 2:
 	=> ask_2
 elif riddle_options.size() == 3:

--- a/scripts/level_initializer.gd
+++ b/scripts/level_initializer.gd
@@ -1,8 +1,13 @@
 extends Node2D
 
+signal level_complete
+
 @export var first_pair_number: int = 1
 @export var fixed_seed: int = -1
 @export var print_assignments: bool = true
+
+var _total_pairs: int = 0
+var _pairs_matched: int = 0
 
 
 func _ready() -> void:
@@ -33,8 +38,20 @@ func _assign_random_hidden_values() -> void:
 	for i in range(npcs.size()):
 		npcs[i].hidden_value = values[i]
 
+	_total_pairs = pair_count
+	_pairs_matched = 0
+	for npc in npcs:
+		npc.match_succeeded.connect(_on_match_succeeded)
+
 	if print_assignments:
 		_print_assignments(npcs)
+
+
+func _on_match_succeeded(_npc1: NPC, _npc2: NPC) -> void:
+	_pairs_matched += 1
+	if _pairs_matched >= _total_pairs:
+		level_complete.emit()
+		print("Level complete! All pairs matched.")
 
 
 func _find_npcs() -> Array[NPC]:

--- a/scripts/npcs/npc.gd
+++ b/scripts/npcs/npc.gd
@@ -5,6 +5,7 @@ signal patience_changed(new_patience: float, max_patience: float)
 signal patience_depleted
 signal number_revealed(number: int)
 signal answer_refused
+signal match_succeeded(npc1: NPC, npc2: NPC)
 
 ## Name shown in dialogue
 @export var npc_name: String = "Party NPC"
@@ -16,8 +17,19 @@ signal answer_refused
 @export var max_patience: float = 5.0
 @export var patience_per_ask: float = 1.0
 
+## Following behaviour
+@export var follow_speed: float = 80.0
+@export var follow_stop_distance: float = 50.0
+## Patience lost per second while following
+@export var follow_patience_drain: float = 0.1
+## Patience slowly recovered per second when not following
+@export var patience_regen_rate: float = 0.04
+
 ## Physics tuning for the grounded NPC body
 @export var gravity: float = 900.0
+@export var jump_velocity: float = -380.0
+## How many px above the NPC the player must be to trigger a jump
+@export var jump_height_threshold: float = 60.0
 @export var prompt_text: String = "Talk"
 
 @export var dialogue_resource: DialogueResource
@@ -29,11 +41,22 @@ var current_balloon: Node = null
 var patience: float
 var patience_bar: ProgressBar
 
+## Following state
+var is_following: bool = false
+var follow_target: Node2D = null
+var _interactor: Node = null
+var _jump_cooldown: float = 0.0
+var _is_matched: bool = false
+
 @onready var _interaction_area: NPCInteractionArea = $InteractionArea
 
 
 func _ready() -> void:
 	patience = max_patience
+	# NPCs on layer 3 (value 4), collide only with world layer 1
+	collision_layer = 4
+	collision_mask = 1
+	add_to_group("npcs")
 	_setup_patience_bar()
 	_sync_prompt()
 
@@ -42,16 +65,14 @@ func _setup_patience_bar() -> void:
 	patience_bar = ProgressBar.new()
 	add_child(patience_bar)
 
-	# Basic styling and positioning
 	patience_bar.show_percentage = false
 	patience_bar.custom_minimum_size = Vector2(40, 6)
 	patience_bar.size = patience_bar.custom_minimum_size
-	patience_bar.position = Vector2(-20, -45) # Above the NPC
+	patience_bar.position = Vector2(-20, -45)
 
 	patience_bar.max_value = max_patience
 	patience_bar.value = patience
 
-	# Optional: Make it look like a small bar
 	var style_bg = StyleBoxFlat.new()
 	style_bg.bg_color = Color(0.2, 0.2, 0.2, 0.8)
 	patience_bar.add_theme_stylebox_override("background", style_bg)
@@ -62,20 +83,55 @@ func _setup_patience_bar() -> void:
 
 
 func _physics_process(delta: float) -> void:
+	if _is_matched:
+		return
 	_apply_gravity(delta)
+	if is_following and follow_target != null:
+		_handle_following(delta)
+	else:
+		_regen_patience(delta)
 	move_and_slide()
 
 
+func _handle_following(delta: float) -> void:
+	var diff_x := follow_target.global_position.x - global_position.x
+	var dist := absf(diff_x)
+	if dist > follow_stop_distance:
+		velocity.x = signf(diff_x) * follow_speed
+	else:
+		velocity.x = move_toward(velocity.x, 0.0, 400.0 * delta)
+
+	_jump_cooldown = maxf(_jump_cooldown - delta, 0.0)
+	var height_diff := global_position.y - follow_target.global_position.y
+	if is_on_floor() and _jump_cooldown <= 0.0 and height_diff > jump_height_threshold:
+		velocity.y = jump_velocity
+		_jump_cooldown = 0.8
+
+	_decrease_patience(follow_patience_drain * delta)
+	if patience <= 0.0:
+		stop_following()
+
+
+func _regen_patience(delta: float) -> void:
+	if patience >= max_patience:
+		return
+	patience = minf(patience + patience_regen_rate * delta, max_patience)
+	if patience_bar:
+		patience_bar.value = patience
+
+
 # Called when the player presses interact while in range
-func interact(_interactor: Node) -> void:                                                                                                                    
-	if dialogue_resource == null or _is_dialogue_active:                                                                                                     
-		return                                          
-	_is_dialogue_active = true                                                                                                                               
+func interact(interactor: Node) -> void:
+	if _is_matched or dialogue_resource == null or _is_dialogue_active:
+		return
+	_interactor = interactor
+	_is_dialogue_active = true
 	current_balloon = DialogueManager.show_dialogue_balloon(dialogue_resource, get_dialogue_start(), [self])
-	await DialogueManager.dialogue_ended                                    
+	await DialogueManager.dialogue_ended
 	_is_dialogue_active = false
 	current_balloon = null
-	_decrease_patience(patience_per_ask)
+	if not _is_matched:
+		_decrease_patience(patience_per_ask)
 
 
 func get_dialogue_start() -> String:
@@ -110,6 +166,78 @@ func restore_patience(amount: float) -> void:
 	if patience_bar:
 		patience_bar.value = patience
 	patience_changed.emit(patience, max_patience)
+
+
+# --- Following ---
+
+func start_following() -> void:
+	if _interactor == null:
+		return
+	# Only one follower at a time — stop the previous one first
+	for node in get_tree().get_nodes_in_group("following_npcs"):
+		if node != self and node is NPC:
+			(node as NPC).stop_following()
+	is_following = true
+	follow_target = _interactor as Node2D
+	add_to_group("following_npcs")
+	_sync_prompt()
+
+
+func stop_following() -> void:
+	is_following = false
+	follow_target = null
+	if is_in_group("following_npcs"):
+		remove_from_group("following_npcs")
+	_sync_prompt()
+
+
+# True when there is a follower in the scene and this NPC is not the one following.
+# Used to decide whether to show the Match! dialogue option.
+func can_attempt_match() -> bool:
+	if is_following:
+		return false
+	for node in get_tree().get_nodes_in_group("following_npcs"):
+		if node != self and node is NPC:
+			return true
+	return false
+
+
+# Tries to match this NPC with the current follower.
+# Success: both NPCs deactivate and match_succeeded is emitted.
+# Fail: all NPCs lose patience (wrong guess penalty).
+func try_match() -> void:
+	var follower: NPC = null
+	for node in get_tree().get_nodes_in_group("following_npcs"):
+		if node != self and node is NPC:
+			follower = node as NPC
+			break
+
+	if follower == null:
+		return
+
+	if follower.hidden_value == hidden_value:
+		follower.stop_following()
+		match_succeeded.emit(self, follower)
+		_deactivate()
+		follower._deactivate()
+	else:
+		_penalize_all_npcs(1.0)
+
+
+func _penalize_all_npcs(amount: float) -> void:
+	for node in get_tree().get_nodes_in_group("npcs"):
+		if node is NPC and not (node as NPC)._is_matched:
+			(node as NPC)._decrease_patience(amount)
+
+
+func _deactivate() -> void:
+	_is_matched = true
+	visible = false
+	if patience_bar:
+		patience_bar.visible = false
+	if _interaction_area:
+		_interaction_area.set_deferred("monitoring", false)
+		_interaction_area.set_deferred("monitorable", false)
 
 
 func _decrease_patience(amount: float) -> void:

--- a/scripts/npcs/npc_teleporter.gd
+++ b/scripts/npcs/npc_teleporter.gd
@@ -1,8 +1,8 @@
 class_name TeleporterNPC
 extends NPC
 
-@export var teleport_interval_min: float = 3.0
-@export var teleport_interval_max: float = 8.0
+@export var teleport_interval_min: float = 25.0
+@export var teleport_interval_max: float = 40.0
 
 var _teleport_timer: float = 0.0
 
@@ -20,6 +20,9 @@ func _process(delta: float) -> void:
 
 
 func teleport() -> void:
+	if is_following:
+		_reset_teleport_timer()
+		return
 	var points = get_tree().get_nodes_in_group("teleport_points")
 	if points.size() == 0:
 		_reset_teleport_timer()

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -26,6 +26,9 @@ var _current_interactable: Interactable = null
 
 
 func _ready() -> void:
+	# Player on layer 2, collide only with world layer 1 (not NPCs on layer 4)
+	collision_layer = 2
+	collision_mask = 1
 	_setup_interaction_area()
 
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/5e3ff20b-dc52-45de-8aae-d7a0dbee7061


What's new
  Following
  - Ask any NPC to follow you via dialogue; only one follower at a time
  - NPC pursues player horizontally and jumps to reach higher platforms
  - Patience drains slowly while following (0.1/s), regenerates when idle (0.04/s)
  - NPC stops following automatically when patience hits 0

  Matching
  - Talk to a stationary NPC while you have a follower → Match! option
  always appears
  - Numbers match → both NPCs disappear, pair counted toward level completion
  - Numbers don't match → all NPCs lose 1 patience (wrong-guess penalty)
  - Matching uses hidden_value directly, so Jester lies can't produce false matches

  Level completion
  - LevelInitializer now emits level_complete signal when all pairs are
  matched
  
  NPC improvements
  - Collision layers separated: world = 1, player = 2, NPCs = 4 (no
  physics blocking each other)
  - TeleporterNPC cooldown raised to 25–40s; won't teleport while being
  followed
  - All follow/jump/drain/regen values are @export and tunable per-NPC in
  the inspector